### PR TITLE
added error handling to GUI when callbacks return false

### DIFF
--- a/src/gui/ForwardingPane.kt
+++ b/src/gui/ForwardingPane.kt
@@ -164,12 +164,12 @@ class ForwardingPane:GridPane()
 
                 // sync up the addressPairs map: remove old entries
                 val toRemove = _addressPairs.filter {it !in allAddressPairs}
-                toRemove.forEach {listener?.removed(it)}
+                Platform.runLater {toRemove.forEach {listener?.removed(it)}}
                 _addressPairs.removeAll(toRemove)
 
                 // sync up the addressPairs map: add new entries
                 val toAdd = allAddressPairs.filter {it !in _addressPairs}
-                toAdd.forEach {listener?.added(it)}
+                Platform.runLater {toAdd.forEach {listener?.added(it)}}
                 _addressPairs.addAll(toAdd)
             }
         }

--- a/src/gui/GUI.kt
+++ b/src/gui/GUI.kt
@@ -1,15 +1,16 @@
 package gui
 
 import javafx.application.Application
+import javafx.application.Platform
 import javafx.collections.ObservableSet
 import javafx.collections.SetChangeListener
 import javafx.scene.Scene
+import javafx.scene.control.Alert
 import javafx.scene.control.ScrollPane
 import javafx.scene.layout.BorderPane
 import javafx.stage.Stage
 import tools.AddressPair
 import java.net.InetSocketAddress
-import java.util.LinkedHashSet
 import java.util.concurrent.CountDownLatch
 
 private var _gui:GUI? = null
@@ -150,13 +151,41 @@ class GUI:Application()
         override fun added(addressPair:AddressPair)
         {
             // todo: check the retturn result
-            listeners?.insert(addressPair)
+            if (listeners?.insert(addressPair) == false)
+            {
+                val alert = Alert(Alert.AlertType.ERROR)
+                alert.title = "Port Forwarder"
+                alert.headerText = "Persistence Failure"
+                alert.contentText =
+"""OHHHH MY GAAWWWD!!! Failed to insert entry: "${addressPair.localPort} -> ${addressPair.dest}" into persistent storage; it will be removed from the address pair list.
+
+You can try:
+    • reentering the data
+    • replacing your hard drive"""
+                alert.showAndWait()
+
+                addressPairs.remove(addressPair)
+            }
         }
 
         override fun removed(addressPair:AddressPair)
         {
-            // todo: check the retturn result
-            listeners?.delete(addressPair)
+            // todo: check the return result
+            if (listeners?.delete(addressPair) == false)
+            {
+                val alert = Alert(Alert.AlertType.ERROR)
+                alert.title = "Port Forwarder"
+                alert.headerText = "Persistence Failure"
+                alert.contentText =
+"""OH NOOOOO! Failed to remove entry: "${addressPair.localPort} -> ${addressPair.dest}" from persistent storage; it will be re-inserted into the address pair list.
+
+You can try:
+    • removing the entry again
+    • giving up"""
+                alert.showAndWait()
+
+                addressPairs.add(addressPair)
+            }
         }
     }
 }


### PR DESCRIPTION
implemented some error dialogs that pop up when the GUI callbacks return false, indicating a persistence error
